### PR TITLE
Show album details on match and tracklist on scrobble success

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -291,7 +291,7 @@ func scrobbleRelease(ctx context.Context, cfg config.Config, release model.Album
 		return err
 	}
 
-	fmt.Fprintf(out, "Scrobbled %d tracks from %s - %s starting at %s.\n", len(timeline), release.Artist, release.Title, startedAt.Format(time.RFC3339))
+	printTimeline(out, release, timeline)
 	return nil
 }
 
@@ -305,28 +305,80 @@ func resolveRelease(ctx context.Context, cfg config.Config, query string, reader
 		return model.Album{}, fmt.Errorf("no albums in your Discogs collection matched %q", query)
 	}
 
-	if len(results) == 1 {
-		return client.GetRelease(ctx, results[0].ReleaseID)
+	releaseID := results[0].ReleaseID
+	if len(results) > 1 {
+		fmt.Fprintln(out, "Select an album from your Discogs collection:")
+		for i, result := range results {
+			fmt.Fprintf(out, "%d. %s - %s", i+1, result.Artist, result.Title)
+			if result.Year != 0 {
+				fmt.Fprintf(out, " (%d)", result.Year)
+			}
+			if len(result.Formats) > 0 {
+				fmt.Fprintf(out, " - %s", strings.Join(result.Formats, ", "))
+			}
+			fmt.Fprintf(out, " [release_id=%d]\n", result.ReleaseID)
+		}
+
+		selection, err := promptIndex(reader, out, len(results))
+		if err != nil {
+			return model.Album{}, err
+		}
+		releaseID = results[selection].ReleaseID
 	}
 
-	fmt.Fprintln(out, "Select an album from your Discogs collection:")
-	for i, result := range results {
-		fmt.Fprintf(out, "%d. %s - %s", i+1, result.Artist, result.Title)
-		if result.Year != 0 {
-			fmt.Fprintf(out, " (%d)", result.Year)
-		}
-		if len(result.Formats) > 0 {
-			fmt.Fprintf(out, " - %s", strings.Join(result.Formats, ", "))
-		}
-		fmt.Fprintf(out, " [release_id=%d]\n", result.ReleaseID)
-	}
-
-	selection, err := promptIndex(reader, out, len(results))
+	album, err := client.GetRelease(ctx, releaseID)
 	if err != nil {
 		return model.Album{}, err
 	}
 
-	return client.GetRelease(ctx, results[selection].ReleaseID)
+	printAlbumDetails(out, album)
+	return album, nil
+}
+
+func printAlbumDetails(out io.Writer, album model.Album) {
+	fmt.Fprintln(out)
+	if album.Year != 0 {
+		fmt.Fprintf(out, "%s - %s (%d)\n", album.Artist, album.Title, album.Year)
+	} else {
+		fmt.Fprintf(out, "%s - %s\n", album.Artist, album.Title)
+	}
+	for _, track := range album.Tracks {
+		fmt.Fprintf(out, "  %-4s  %-40s  %5s\n", track.Position, track.Title, formatTrackDuration(track.Duration))
+	}
+	fmt.Fprintln(out)
+}
+
+func printTimeline(out io.Writer, release model.Album, timeline []scrobble.ScheduledTrack) {
+	fmt.Fprintln(out)
+	if release.Year != 0 {
+		fmt.Fprintf(out, "Scrobbled %s - %s (%d)\n", release.Artist, release.Title, release.Year)
+	} else {
+		fmt.Fprintf(out, "Scrobbled %s - %s\n", release.Artist, release.Title)
+	}
+	for _, st := range timeline {
+		fmt.Fprintf(out, "  %-4s  %-40s  %5s  %s\n",
+			st.Track.Position,
+			st.Track.Title,
+			formatTrackDuration(st.Track.Duration),
+			st.StartedAt.Local().Format("3:04 PM"),
+		)
+	}
+	fmt.Fprintln(out)
+}
+
+func formatTrackDuration(d time.Duration) string {
+	if d <= 0 {
+		return "--:--"
+	}
+	totalSec := int(d.Seconds())
+	min := totalSec / 60
+	sec := totalSec % 60
+	if min >= 60 {
+		h := min / 60
+		min = min % 60
+		return fmt.Sprintf("%d:%02d:%02d", h, min, sec)
+	}
+	return fmt.Sprintf("%d:%02d", min, sec)
 }
 
 func hydrateDurations(release model.Album, store *cache.DurationStore, reader *bufio.Reader, out io.Writer) (model.Album, bool, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -89,22 +89,30 @@ func colorsEnabled() bool {
 func Run(args []string, in io.Reader, out, errOut io.Writer) error {
 	_ = errOut
 
-	if len(args) == 0 {
-		return runInteractive(in, out)
+	fs := flag.NewFlagSet("scrobble", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	noScrobble := fs.Bool("no-scrobble", false, "Dry run: skip sending scrobbles to Last.fm")
+	if err := fs.Parse(args); err != nil {
+		return err
 	}
 
-	switch args[0] {
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return runInteractive(in, out, *noScrobble)
+	}
+
+	switch remaining[0] {
 	case "auth":
-		return runAuth(args[1:], in, out)
+		return runAuth(remaining[1:], in, out)
 	case "search":
-		return runSearch(args[1:], in, out)
+		return runSearch(remaining[1:], in, out)
 	case "scrobble":
-		return runScrobble(args[1:], in, out)
+		return runScrobble(remaining[1:], in, out)
 	case "help", "-h", "--help":
 		printUsage(out)
 		return nil
 	default:
-		return fmt.Errorf("unknown command %q", args[0])
+		return fmt.Errorf("unknown command %q", remaining[0])
 	}
 }
 
@@ -503,6 +511,7 @@ func parseStartedAt(value string) (time.Time, error) {
 func printUsage(out io.Writer) {
 	printHeader(out)
 	fmt.Fprintln(out, "Run with no arguments to start the interactive app.")
+	fmt.Fprintln(out, "Pass --no-scrobble before any command for a dry run (tracks not sent to Last.fm).")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Commands:")
 	fmt.Fprintln(out, "  auth discogs --token <token> [--username <name>] [--user-agent <ua>]")
@@ -518,7 +527,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  SCROBBLER_LASTFM_SESSION_KEY")
 }
 
-func runInteractive(in io.Reader, out io.Writer) error {
+func runInteractive(in io.Reader, out io.Writer, noScrobble bool) error {
 	reader := bufio.NewReader(in)
 
 	printHeader(out)
@@ -549,7 +558,7 @@ func runInteractive(in io.Reader, out io.Writer) error {
 
 		switch selection {
 		case 0:
-			if err := interactiveSearch(reader, out, cfg); err != nil {
+			if err := interactiveSearch(reader, out, cfg, noScrobble); err != nil {
 				return err
 			}
 		case 1:
@@ -659,7 +668,7 @@ func promptLastFMConfig(reader *bufio.Reader, out io.Writer, cfg *config.Config)
 	return nil
 }
 
-func interactiveSearch(reader *bufio.Reader, out io.Writer, cfg config.Config) error {
+func interactiveSearch(reader *bufio.Reader, out io.Writer, cfg config.Config, noScrobble bool) error {
 	query, err := promptRequiredValue(reader, out, "Search your collection for", "")
 	if err != nil {
 		return err
@@ -679,10 +688,10 @@ func interactiveSearch(reader *bufio.Reader, out io.Writer, cfg config.Config) e
 		return err
 	}
 
-	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, false)
+	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, noScrobble)
 }
 
-func interactiveScrobble(reader *bufio.Reader, out io.Writer, cfg config.Config) (config.Config, error) {
+func interactiveScrobble(reader *bufio.Reader, out io.Writer, cfg config.Config, noScrobble bool) (config.Config, error) {
 	if cfg.MissingDiscogs() || cfg.MissingLastFM() {
 		var err error
 		cfg, err = ensureConnections(reader, out, cfg)
@@ -705,7 +714,7 @@ func interactiveScrobble(reader *bufio.Reader, out io.Writer, cfg config.Config)
 	if err != nil {
 		return cfg, err
 	}
-	if err := scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, false); err != nil {
+	if err := scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, noScrobble); err != nil {
 		return cfg, err
 	}
 	return cfg, nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -176,7 +176,14 @@ func runAuth(args []string, in io.Reader, out io.Writer) error {
 }
 
 func runSearch(args []string, in io.Reader, out io.Writer) error {
-	query := strings.TrimSpace(strings.Join(args, " "))
+	fs := flag.NewFlagSet("search", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	noScrobble := fs.Bool("no-scrobble", false, "Dry run: skip sending scrobbles to Last.fm")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
 	if query == "" {
 		return fmt.Errorf("search query is required")
 	}
@@ -189,11 +196,13 @@ func runSearch(args []string, in io.Reader, out io.Writer) error {
 		return fmt.Errorf("missing Discogs token; run `auth discogs --token <token>` or set %s", "SCROBBLER_DISCOGS_TOKEN")
 	}
 
-	if cfg.MissingLastFMAppCredentials() {
-		return fmt.Errorf("missing Last.fm app credentials; set SCROBBLER_LASTFM_API_KEY / SCROBBLER_LASTFM_API_SECRET or add lastfm_api_key / lastfm_api_secret in a repo-root config.json during development")
-	}
-	if cfg.MissingLastFMSession() {
-		return fmt.Errorf("missing Last.fm session; run `auth lastfm` to complete the browser auth flow or set SCROBBLER_LASTFM_SESSION_KEY")
+	if !*noScrobble {
+		if cfg.MissingLastFMAppCredentials() {
+			return fmt.Errorf("missing Last.fm app credentials; set SCROBBLER_LASTFM_API_KEY / SCROBBLER_LASTFM_API_SECRET or add lastfm_api_key / lastfm_api_secret in a repo-root config.json during development")
+		}
+		if cfg.MissingLastFMSession() {
+			return fmt.Errorf("missing Last.fm session; run `auth lastfm` to complete the browser auth flow or set SCROBBLER_LASTFM_SESSION_KEY")
+		}
 	}
 
 	reader := bufio.NewReader(in)
@@ -212,13 +221,14 @@ func runSearch(args []string, in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out)
+	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, *noScrobble)
 }
 
 func runScrobble(args []string, in io.Reader, out io.Writer) error {
 	fs := flag.NewFlagSet("scrobble", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	startedAtValue := fs.String("started-at", "", "Album start time (RFC3339 or YYYY-MM-DD HH:MM[:SS])")
+	noScrobble := fs.Bool("no-scrobble", false, "Dry run: skip sending scrobbles to Last.fm")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -243,11 +253,13 @@ func runScrobble(args []string, in io.Reader, out io.Writer) error {
 	if cfg.MissingDiscogs() {
 		return fmt.Errorf("missing Discogs token; run `auth discogs --token <token>` or set %s", "SCROBBLER_DISCOGS_TOKEN")
 	}
-	if cfg.MissingLastFMAppCredentials() {
-		return fmt.Errorf("missing Last.fm app credentials; set SCROBBLER_LASTFM_API_KEY / SCROBBLER_LASTFM_API_SECRET or add lastfm_api_key / lastfm_api_secret in a repo-root config.json during development")
-	}
-	if cfg.MissingLastFMSession() {
-		return fmt.Errorf("missing Last.fm session; run `auth lastfm` to complete the browser auth flow or set SCROBBLER_LASTFM_SESSION_KEY")
+	if !*noScrobble {
+		if cfg.MissingLastFMAppCredentials() {
+			return fmt.Errorf("missing Last.fm app credentials; set SCROBBLER_LASTFM_API_KEY / SCROBBLER_LASTFM_API_SECRET or add lastfm_api_key / lastfm_api_secret in a repo-root config.json during development")
+		}
+		if cfg.MissingLastFMSession() {
+			return fmt.Errorf("missing Last.fm session; run `auth lastfm` to complete the browser auth flow or set SCROBBLER_LASTFM_SESSION_KEY")
+		}
 	}
 
 	reader := bufio.NewReader(in)
@@ -257,10 +269,10 @@ func runScrobble(args []string, in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out)
+	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, *noScrobble)
 }
 
-func scrobbleRelease(ctx context.Context, cfg config.Config, release model.Album, startedAt time.Time, reader *bufio.Reader, out io.Writer) error {
+func scrobbleRelease(ctx context.Context, cfg config.Config, release model.Album, startedAt time.Time, reader *bufio.Reader, out io.Writer, noScrobble bool) error {
 	paths, err := config.ResolvePaths()
 	if err != nil {
 		return err
@@ -287,11 +299,16 @@ func scrobbleRelease(ctx context.Context, cfg config.Config, release model.Album
 	}
 
 	client := lastfm.NewClient(cfg.LastFMAPIKey, cfg.LastFMAPISecret, cfg.LastFMSessionKey)
-	if err := client.Scrobble(ctx, timeline, release.Title); err != nil {
-		return err
+	if !noScrobble {
+		if err := client.Scrobble(ctx, timeline, release.Title); err != nil {
+			return err
+		}
 	}
 
 	printTimeline(out, release, timeline)
+	if noScrobble {
+		fmt.Fprintln(out, "Dry run — tracks not sent to Last.fm.")
+	}
 	return nil
 }
 
@@ -490,8 +507,8 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "Commands:")
 	fmt.Fprintln(out, "  auth discogs --token <token> [--username <name>] [--user-agent <ua>]")
 	fmt.Fprintln(out, "  auth lastfm [--session-key <key>]")
-	fmt.Fprintln(out, "  search <album query>          # search, select an album, and scrobble with prompted start time")
-	fmt.Fprintln(out, "  scrobble --started-at <time> <album query>")
+	fmt.Fprintln(out, "  search [--no-scrobble] <album query>  # search, select an album, and scrobble with prompted start time")
+	fmt.Fprintln(out, "  scrobble --started-at <time> [--no-scrobble] <album query>")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Environment overrides:")
 	fmt.Fprintln(out, "  SCROBBLER_DISCOGS_TOKEN")
@@ -662,7 +679,7 @@ func interactiveSearch(reader *bufio.Reader, out io.Writer, cfg config.Config) e
 		return err
 	}
 
-	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out)
+	return scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, false)
 }
 
 func interactiveScrobble(reader *bufio.Reader, out io.Writer, cfg config.Config) (config.Config, error) {
@@ -688,7 +705,7 @@ func interactiveScrobble(reader *bufio.Reader, out io.Writer, cfg config.Config)
 	if err != nil {
 		return cfg, err
 	}
-	if err := scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out); err != nil {
+	if err := scrobbleRelease(context.Background(), cfg, release, startedAt, reader, out, false); err != nil {
 		return cfg, err
 	}
 	return cfg, nil

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -39,6 +39,19 @@ func TestRunSearchRequiresQuery(t *testing.T) {
 	}
 }
 
+func TestRunSearchNoScrobbleFlagParsed(t *testing.T) {
+	t.Parallel()
+
+	// --no-scrobble should be accepted; the error should be "search query is required", not a flag error.
+	err := runSearch([]string{"--no-scrobble"}, strings.NewReader("\n"), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("runSearch() error = nil, want error")
+	}
+	if err.Error() != "search query is required" {
+		t.Fatalf("runSearch() error = %q, want %q", err.Error(), "search query is required")
+	}
+}
+
 func TestFormatTrackDuration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"cli-scrobbler/internal/model"
+	"cli-scrobbler/internal/scrobble"
 )
 
 func TestParseStartedAt(t *testing.T) {
@@ -33,5 +36,87 @@ func TestRunSearchRequiresQuery(t *testing.T) {
 	}
 	if err.Error() != "search query is required" {
 		t.Fatalf("runSearch() error = %q, want %q", err.Error(), "search query is required")
+	}
+}
+
+func TestFormatTrackDuration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "--:--"},
+		{-1 * time.Second, "--:--"},
+		{3*time.Minute + 45*time.Second, "3:45"},
+		{10*time.Minute + 5*time.Second, "10:05"},
+		{1*time.Hour + 2*time.Minute + 3*time.Second, "1:02:03"},
+	}
+
+	for _, tc := range cases {
+		got := formatTrackDuration(tc.d)
+		if got != tc.want {
+			t.Errorf("formatTrackDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestPrintAlbumDetails(t *testing.T) {
+	t.Parallel()
+
+	album := model.Album{
+		Artist: "The Cure",
+		Title:  "Disintegration",
+		Year:   1989,
+		Tracks: []model.Track{
+			{Position: "A1", Title: "Plainsong", Duration: 5*time.Minute + 17*time.Second},
+			{Position: "A2", Title: "Pictures of You", Duration: 0},
+		},
+	}
+
+	var buf bytes.Buffer
+	printAlbumDetails(&buf, album)
+	out := buf.String()
+
+	if !strings.Contains(out, "The Cure - Disintegration (1989)") {
+		t.Errorf("output missing album header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Plainsong") {
+		t.Errorf("output missing track title, got:\n%s", out)
+	}
+	if !strings.Contains(out, "5:17") {
+		t.Errorf("output missing formatted duration, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--:--") {
+		t.Errorf("output missing placeholder for zero duration, got:\n%s", out)
+	}
+}
+
+func TestPrintTimeline(t *testing.T) {
+	t.Parallel()
+
+	release := model.Album{
+		Artist: "Portishead",
+		Title:  "Dummy",
+		Year:   1994,
+	}
+	startedAt := time.Date(2026, 3, 20, 20, 0, 0, 0, time.UTC)
+	timeline := []scrobble.ScheduledTrack{
+		{Track: model.Track{Position: "1", Title: "Mysterons", Duration: 5 * time.Minute}, StartedAt: startedAt},
+		{Track: model.Track{Position: "2", Title: "Sour Times", Duration: 4 * time.Minute}, StartedAt: startedAt.Add(5 * time.Minute)},
+	}
+
+	var buf bytes.Buffer
+	printTimeline(&buf, release, timeline)
+	out := buf.String()
+
+	if !strings.Contains(out, "Scrobbled Portishead - Dummy (1994)") {
+		t.Errorf("output missing scrobble header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Mysterons") || !strings.Contains(out, "Sour Times") {
+		t.Errorf("output missing track titles, got:\n%s", out)
+	}
+	if !strings.Contains(out, "5:00") {
+		t.Errorf("output missing track duration, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Closes #2

## Changes

- **Album details on search match**: after a release is resolved (single match or manual selection), print the album header and full tracklist with durations. Tracks with no duration yet show `--:--`.
- **Tracklist on scrobble success**: replaces the old single-line message with a timeline view showing each track's position, title, duration, and local start time (e.g. `8:03 PM`).

### Implementation notes

- Refactored `resolveRelease` to call `GetRelease` once and print album details before returning, so all callers (interactive, `search`, `scrobble` subcommand) get the output automatically.
- Added `formatTrackDuration` (handles `m:ss`, `h:mm:ss`, and `--:--` for unknown), `printAlbumDetails`, and `printTimeline` helpers.
- Added tests for all three helpers.