### PR TITLE
Fix Codecov upload authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,10 @@ jobs:
           path: coverage.out
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.out
-          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           verbose: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Scrobble albums from your Discogs collection to Last.fm from the command line.
 
-To publish coverage on GitHub, enable the Codecov app for this repository so the coverage upload step in CI can report status and render the badge.
+To publish coverage on GitHub, enable the Codecov GitHub app for this repository, add the repository upload token as a GitHub Actions secret named `CODECOV_TOKEN`, and rerun CI on `main` so the badge can pick up the first successful upload.
 
 The app helps you:
 
@@ -131,4 +131,3 @@ To avoid passing `-ldflags` every build during development, create a repo-root `
 ## License
 
 This project is licensed under the MIT License. You can use, modify, fork, and redistribute it, including commercially, as long as the copyright and license notice are preserved.
-


### PR DESCRIPTION
## Summary
- pass the Codecov upload token from GitHub Actions
- fail the workflow if Codecov rejects the upload
- document the required Codecov app and CODECOV_TOKEN setup in the README

## Testing
- go test ./...
- go build -o scrobble ./cmd/scrobble
