### PR TITLE
Add repository codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  branch: main
+  strict_yaml_branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true


### PR DESCRIPTION
## Summary
- add a minimal root-level codecov.yml
- pin Codecov's configured branch to main
- enable basic project and patch status configuration

## Why
- Codecov uploads succeed, but the badge still shows unknown
- this makes Codecov's branch and status behavior explicit at the repo level
