### PR TITLE
Add high-ROI coverage tests

### DIFF
--- a/internal/app/command_flows_test.go
+++ b/internal/app/command_flows_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestRunAuthDiscogsSavesConfig(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	restore := chdirForAppTest(t, t.TempDir())
 	defer restore()
 
@@ -38,8 +37,7 @@ func TestRunAuthDiscogsSavesConfig(t *testing.T) {
 }
 
 func TestRunAuthLastFMSavesProvidedSessionKey(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	t.Setenv("SCROBBLER_LASTFM_API_KEY", "api-key")
 	t.Setenv("SCROBBLER_LASTFM_API_SECRET", "api-secret")
 	restore := chdirForAppTest(t, t.TempDir())
@@ -64,8 +62,7 @@ func TestRunAuthLastFMSavesProvidedSessionKey(t *testing.T) {
 }
 
 func TestRunAuthLastFMRequiresCredentials(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	restore := chdirForAppTest(t, t.TempDir())
 	defer restore()
 
@@ -79,8 +76,7 @@ func TestRunAuthLastFMRequiresCredentials(t *testing.T) {
 }
 
 func TestRunSearchDryRunUsesDiscogsResults(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	restore := chdirForAppTest(t, t.TempDir())
 	defer restore()
 	writeUserConfig(t, "{\n  \"discogs_token\": \"discogs-token\",\n  \"discogs_username\": \"discogs-user\",\n  \"discogs_user_agent\": \"agent/1.0\"\n}\n")
@@ -131,8 +127,7 @@ func TestRunSearchDryRunUsesDiscogsResults(t *testing.T) {
 }
 
 func TestRunSearchNoMatchesPrintsFriendlyMessage(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	restore := chdirForAppTest(t, t.TempDir())
 	defer restore()
 	writeUserConfig(t, "{\n  \"discogs_token\": \"discogs-token\",\n  \"discogs_username\": \"discogs-user\",\n  \"discogs_user_agent\": \"agent/1.0\"\n}\n")
@@ -161,8 +156,7 @@ func TestRunSearchNoMatchesPrintsFriendlyMessage(t *testing.T) {
 }
 
 func TestRunScrobbleSendsTracksToLastFM(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	t.Setenv("SCROBBLER_LASTFM_API_KEY", "api-key")
 	t.Setenv("SCROBBLER_LASTFM_API_SECRET", "api-secret")
 	t.Setenv("SCROBBLER_LASTFM_SESSION_KEY", "session-key")

--- a/internal/app/command_flows_test.go
+++ b/internal/app/command_flows_test.go
@@ -1,0 +1,259 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"cli-scrobbler/internal/config"
+	"cli-scrobbler/internal/discogs"
+	"cli-scrobbler/internal/lastfm"
+)
+
+func TestRunAuthDiscogsSavesConfig(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+
+	var out bytes.Buffer
+	err := runAuth([]string{"discogs", "--token", "discogs-token", "--username", "discogs-user", "--user-agent", "agent/2.0"}, strings.NewReader(""), &out)
+	if err != nil {
+		t.Fatalf("runAuth(discogs) error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Saved Discogs credentials.") {
+		t.Fatalf("runAuth(discogs) output = %q, want saved message", out.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.DiscogsToken != "discogs-token" || cfg.DiscogsUsername != "discogs-user" || cfg.DiscogsUserAgent != "agent/2.0" {
+		t.Fatalf("saved config = %#v", cfg)
+	}
+}
+
+func TestRunAuthLastFMSavesProvidedSessionKey(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("SCROBBLER_LASTFM_API_KEY", "api-key")
+	t.Setenv("SCROBBLER_LASTFM_API_SECRET", "api-secret")
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+
+	var out bytes.Buffer
+	err := runAuth([]string{"lastfm", "--session-key", "session-123"}, strings.NewReader(""), &out)
+	if err != nil {
+		t.Fatalf("runAuth(lastfm) error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Saved Last.fm session.") {
+		t.Fatalf("runAuth(lastfm) output = %q, want saved message", out.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.LastFMSessionKey != "session-123" {
+		t.Fatalf("saved session key = %q, want %q", cfg.LastFMSessionKey, "session-123")
+	}
+}
+
+func TestRunAuthLastFMRequiresCredentials(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+
+	err := runAuth([]string{"lastfm", "--session-key", "session-123"}, strings.NewReader(""), io.Discard)
+	if err == nil {
+		t.Fatal("runAuth(lastfm) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "missing Last.fm app credentials") {
+		t.Fatalf("runAuth(lastfm) error = %q, want missing credentials", err.Error())
+	}
+}
+
+func TestRunSearchDryRunUsesDiscogsResults(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+	writeUserConfig(t, "{\n  \"discogs_token\": \"discogs-token\",\n  \"discogs_username\": \"discogs-user\",\n  \"discogs_user_agent\": \"agent/1.0\"\n}\n")
+
+	restoreClients := stubAppClients(t, func(token, userAgent string) *discogs.Client {
+		return discogs.NewClientWithHTTPClient(token, userAgent, &http.Client{
+			Transport: appRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case strings.HasPrefix(req.URL.Path, "/users/discogs-user/collection/folders/0/releases"):
+					return jsonResponse(`{
+						"pagination":{"page":1,"pages":1},
+						"releases":[
+							{"basic_information":{"id":1,"title":"Dummy","year":1994,"artists":[{"name":"Portishead"}],"formats":[{"name":"LP"}]}},
+							{"basic_information":{"id":2,"title":"Dummy","year":2017,"artists":[{"name":"Portishead"}],"formats":[{"name":"LP"},{"name":"Reissue"}]}}
+						]
+					}`), nil
+				case req.URL.Path == "/releases/2":
+					return jsonResponse(`{
+						"id":2,
+						"title":"Dummy",
+						"year":2017,
+						"artists":[{"name":"Portishead"}],
+						"tracklist":[
+							{"position":"1","title":"Mysterons","duration":"5:02","type_":"track"},
+							{"position":"2","title":"Sour Times","duration":"4:11","type_":"track"}
+						]
+					}`), nil
+				default:
+					t.Fatalf("unexpected Discogs request: %s", req.URL.String())
+					return nil, nil
+				}
+			}),
+		})
+	}, nil)
+	defer restoreClients()
+
+	var out bytes.Buffer
+	err := runSearch([]string{"--no-scrobble", "dummy"}, strings.NewReader("1\n2026-03-20 20:00\n"), &out)
+	if err != nil {
+		t.Fatalf("runSearch() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Select an album from your Discogs collection:") {
+		t.Fatalf("runSearch() output missing selection prompt: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "Dry run") {
+		t.Fatalf("runSearch() output missing dry-run message: %q", out.String())
+	}
+}
+
+func TestRunSearchNoMatchesPrintsFriendlyMessage(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+	writeUserConfig(t, "{\n  \"discogs_token\": \"discogs-token\",\n  \"discogs_username\": \"discogs-user\",\n  \"discogs_user_agent\": \"agent/1.0\"\n}\n")
+
+	restoreClients := stubAppClients(t, func(token, userAgent string) *discogs.Client {
+		return discogs.NewClientWithHTTPClient(token, userAgent, &http.Client{
+			Transport: appRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if strings.HasPrefix(req.URL.Path, "/users/discogs-user/collection/folders/0/releases") {
+					return jsonResponse(`{"pagination":{"page":1,"pages":1},"releases":[]}`), nil
+				}
+				t.Fatalf("unexpected Discogs request: %s", req.URL.String())
+				return nil, nil
+			}),
+		})
+	}, nil)
+	defer restoreClients()
+
+	var out bytes.Buffer
+	err := runSearch([]string{"--no-scrobble", "missing"}, strings.NewReader(""), &out)
+	if err != nil {
+		t.Fatalf("runSearch() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "No matching albums found") {
+		t.Fatalf("runSearch() output = %q, want no-match message", out.String())
+	}
+}
+
+func TestRunScrobbleSendsTracksToLastFM(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("SCROBBLER_LASTFM_API_KEY", "api-key")
+	t.Setenv("SCROBBLER_LASTFM_API_SECRET", "api-secret")
+	t.Setenv("SCROBBLER_LASTFM_SESSION_KEY", "session-key")
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+	writeUserConfig(t, "{\n  \"discogs_token\": \"discogs-token\",\n  \"discogs_username\": \"discogs-user\",\n  \"discogs_user_agent\": \"agent/1.0\"\n}\n")
+
+	restoreClients := stubAppClients(t, func(token, userAgent string) *discogs.Client {
+		return discogs.NewClientWithHTTPClient(token, userAgent, &http.Client{
+			Transport: appRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case strings.HasPrefix(req.URL.Path, "/users/discogs-user/collection/folders/0/releases"):
+					return jsonResponse(`{
+						"pagination":{"page":1,"pages":1},
+						"releases":[
+							{"basic_information":{"id":7,"title":"Dummy","year":1994,"artists":[{"name":"Portishead"}],"formats":[{"name":"LP"}]}}
+						]
+					}`), nil
+				case req.URL.Path == "/releases/7":
+					return jsonResponse(`{
+						"id":7,
+						"title":"Dummy",
+						"year":1994,
+						"artists":[{"name":"Portishead"}],
+						"tracklist":[
+							{"position":"1","title":"Mysterons","duration":"5:02","type_":"track"},
+							{"position":"2","title":"Sour Times","duration":"4:11","type_":"track"}
+						]
+					}`), nil
+				default:
+					t.Fatalf("unexpected Discogs request: %s", req.URL.String())
+					return nil, nil
+				}
+			}),
+		})
+	}, func(apiKey, apiSecret, sessionKey string) *lastfm.Client {
+		return lastfm.NewClientWithHTTPClient(apiKey, apiSecret, sessionKey, &http.Client{
+			Transport: appRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("ReadAll(request body) error = %v", err)
+				}
+				values, err := url.ParseQuery(string(body))
+				if err != nil {
+					t.Fatalf("ParseQuery() error = %v", err)
+				}
+				if values.Get("method") != "track.scrobble" {
+					t.Fatalf("method = %q, want %q", values.Get("method"), "track.scrobble")
+				}
+				if values.Get("track[0]") != "Mysterons" || values.Get("track[1]") != "Sour Times" {
+					t.Fatalf("unexpected scrobble payload: %v", values)
+				}
+				return jsonResponse(`{"error":0}`), nil
+			}),
+		})
+	})
+	defer restoreClients()
+
+	var out bytes.Buffer
+	err := runScrobble([]string{"--started-at", "2026-03-20T20:00:00Z", "dummy"}, strings.NewReader(""), &out)
+	if err != nil {
+		t.Fatalf("runScrobble() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Scrobbled Portishead - Dummy") {
+		t.Fatalf("runScrobble() output = %q, want timeline", out.String())
+	}
+}
+
+func stubAppClients(t *testing.T, discogsCtor func(string, string) *discogs.Client, lastFMCtor func(string, string, string) *lastfm.Client) func() {
+	t.Helper()
+
+	oldDiscogs := newDiscogsClient
+	oldLastFM := newLastFMClient
+	if discogsCtor != nil {
+		newDiscogsClient = discogsCtor
+	}
+	if lastFMCtor != nil {
+		newLastFMClient = lastFMCtor
+	}
+
+	return func() {
+		newDiscogsClient = oldDiscogs
+		newLastFMClient = oldLastFM
+	}
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}

--- a/internal/app/deps.go
+++ b/internal/app/deps.go
@@ -1,0 +1,11 @@
+package app
+
+import (
+	"cli-scrobbler/internal/discogs"
+	"cli-scrobbler/internal/lastfm"
+)
+
+var (
+	newDiscogsClient = discogs.NewClient
+	newLastFMClient  = lastfm.NewClient
+)

--- a/internal/app/helpers_test.go
+++ b/internal/app/helpers_test.go
@@ -1,0 +1,317 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"cli-scrobbler/internal/cache"
+	"cli-scrobbler/internal/config"
+	"cli-scrobbler/internal/discogs"
+	"cli-scrobbler/internal/model"
+)
+
+type appRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f appRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestPromptIndexRetriesUntilValid(t *testing.T) {
+	t.Parallel()
+
+	reader := bufio.NewReader(strings.NewReader("0\nabc\n2\n"))
+	var out bytes.Buffer
+
+	got, err := promptIndex(reader, &out, 3)
+	if err != nil {
+		t.Fatalf("promptIndex() error = %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("promptIndex() = %d, want %d", got, 1)
+	}
+	if strings.Count(out.String(), "Please enter a valid selection.") != 2 {
+		t.Fatalf("promptIndex() output = %q, want two validation messages", out.String())
+	}
+}
+
+func TestPromptDurationRetriesUntilValid(t *testing.T) {
+	t.Parallel()
+
+	reader := bufio.NewReader(strings.NewReader("-1\n4:30\n"))
+	var out bytes.Buffer
+
+	got, err := promptDuration(reader, &out, model.Track{Position: "A1", Title: "Intro"})
+	if err != nil {
+		t.Fatalf("promptDuration() error = %v", err)
+	}
+	if got != 4*time.Minute+30*time.Second {
+		t.Fatalf("promptDuration() = %v, want %v", got, 4*time.Minute+30*time.Second)
+	}
+	if !strings.Contains(out.String(), "Invalid duration:") {
+		t.Fatalf("promptDuration() output missing validation message: %q", out.String())
+	}
+}
+
+func TestPromptSecretValueKeepsStoredValue(t *testing.T) {
+	t.Parallel()
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	var out bytes.Buffer
+
+	got, err := promptSecretValue(reader, &out, "Discogs token", "stored-token")
+	if err != nil {
+		t.Fatalf("promptSecretValue() error = %v", err)
+	}
+	if got != "stored-token" {
+		t.Fatalf("promptSecretValue() = %q, want %q", got, "stored-token")
+	}
+}
+
+func TestPromptYesNoRetriesUntilValid(t *testing.T) {
+	t.Parallel()
+
+	reader := bufio.NewReader(strings.NewReader("maybe\nn\n"))
+	var out bytes.Buffer
+
+	got, err := promptYesNo(reader, &out, "Continue?", true)
+	if err != nil {
+		t.Fatalf("promptYesNo() error = %v", err)
+	}
+	if got {
+		t.Fatalf("promptYesNo() = %v, want false", got)
+	}
+	if !strings.Contains(out.String(), "Please answer yes or no.") {
+		t.Fatalf("promptYesNo() output missing retry prompt: %q", out.String())
+	}
+}
+
+func TestEnsureConnectionsReportsConfiguredState(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		DiscogsToken:     "discogs-token",
+		DiscogsUserAgent: "agent/1.0",
+		LastFMAPIKey:     "api-key",
+		LastFMAPISecret:  "api-secret",
+		LastFMSessionKey: "session-key",
+	}
+	var out bytes.Buffer
+
+	got, err := ensureConnections(bufio.NewReader(strings.NewReader("")), &out, cfg)
+	if err != nil {
+		t.Fatalf("ensureConnections() error = %v", err)
+	}
+	if got != cfg {
+		t.Fatalf("ensureConnections() = %#v, want %#v", got, cfg)
+	}
+	if !strings.Contains(out.String(), "configured") {
+		t.Fatalf("ensureConnections() output missing confirmation: %q", out.String())
+	}
+}
+
+func TestPromptDiscogsConfigUpdatesFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		DiscogsToken:     "old-token",
+		DiscogsUsername:  "old-user",
+		DiscogsUserAgent: "old-agent",
+	}
+	reader := bufio.NewReader(strings.NewReader("new-token\nnew-user\nnew-agent\n"))
+
+	if err := promptDiscogsConfig(reader, io.Discard, &cfg); err != nil {
+		t.Fatalf("promptDiscogsConfig() error = %v", err)
+	}
+	if cfg.DiscogsToken != "new-token" || cfg.DiscogsUsername != "new-user" || cfg.DiscogsUserAgent != "new-agent" {
+		t.Fatalf("promptDiscogsConfig() updated cfg = %#v", cfg)
+	}
+}
+
+func TestPromptLastFMConfigRequiresCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{}
+	err := promptLastFMConfig(bufio.NewReader(strings.NewReader("")), io.Discard, &cfg)
+	if err == nil {
+		t.Fatal("promptLastFMConfig() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "missing Last.fm app credentials") {
+		t.Fatalf("promptLastFMConfig() error = %q, want missing credentials", err.Error())
+	}
+}
+
+func TestPromptLastFMConfigKeepsStoredSessionKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		LastFMAPIKey:     "api-key",
+		LastFMAPISecret:  "api-secret",
+		LastFMSessionKey: "stored-session",
+	}
+
+	err := promptLastFMConfig(bufio.NewReader(strings.NewReader("\n")), io.Discard, &cfg)
+	if err != nil {
+		t.Fatalf("promptLastFMConfig() error = %v", err)
+	}
+	if cfg.LastFMSessionKey != "stored-session" {
+		t.Fatalf("promptLastFMConfig() session key = %q, want %q", cfg.LastFMSessionKey, "stored-session")
+	}
+}
+
+func TestHydrateDurationsUsesCacheAndPromptsForMissingTracks(t *testing.T) {
+	t.Parallel()
+
+	store := &cache.DurationStore{Entries: map[string]int64{}}
+	release := model.Album{
+		ReleaseID: 42,
+		Tracks: []model.Track{
+			{Position: "A1", Title: "Cached", Artist: "Artist"},
+			{Position: "A2", Title: "Prompted", Artist: "Artist"},
+		},
+	}
+	store.Put(release.ReleaseID, release.Tracks[0], 90*time.Second)
+
+	reader := bufio.NewReader(strings.NewReader("200\n"))
+	var out bytes.Buffer
+
+	got, asked, err := hydrateDurations(release, store, reader, &out)
+	if err != nil {
+		t.Fatalf("hydrateDurations() error = %v", err)
+	}
+	if !asked {
+		t.Fatal("hydrateDurations() asked = false, want true")
+	}
+	if got.Tracks[0].Duration != 90*time.Second {
+		t.Fatalf("hydrateDurations() cached duration = %v, want %v", got.Tracks[0].Duration, 90*time.Second)
+	}
+	if got.Tracks[1].Duration != 200*time.Second {
+		t.Fatalf("hydrateDurations() prompted duration = %v, want %v", got.Tracks[1].Duration, 200*time.Second)
+	}
+	if cached, ok := store.Lookup(release.ReleaseID, got.Tracks[1]); !ok || cached != 200*time.Second {
+		t.Fatalf("hydrateDurations() failed to persist prompted duration, got %v ok=%v", cached, ok)
+	}
+}
+
+func TestResolveDiscogsUsernameUsesConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	client := discogs.NewClient("discogs-token", "agent/1.0")
+	got, err := resolveDiscogsUsername(context.Background(), client, config.Config{DiscogsUsername: "configured-user"})
+	if err != nil {
+		t.Fatalf("resolveDiscogsUsername() error = %v", err)
+	}
+	if got != "configured-user" {
+		t.Fatalf("resolveDiscogsUsername() = %q, want %q", got, "configured-user")
+	}
+}
+
+func TestResolveDiscogsUsernameWrapsIdentityError(t *testing.T) {
+	t.Parallel()
+
+	client := discogs.NewClientWithHTTPClient("discogs-token", "agent/1.0", &http.Client{
+		Transport: appRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Status:     "401 Unauthorized",
+				Body:       io.NopCloser(strings.NewReader(`{"message":"nope"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	})
+
+	_, err := resolveDiscogsUsername(context.Background(), client, config.Config{})
+	if err == nil {
+		t.Fatal("resolveDiscogsUsername() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "resolve Discogs username:") {
+		t.Fatalf("resolveDiscogsUsername() error = %q, want wrapped context", err.Error())
+	}
+}
+
+func TestScrobbleReleaseDryRunSavesPromptedDurations(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	restore := chdirForAppTest(t, t.TempDir())
+	defer restore()
+
+	release := model.Album{
+		ReleaseID: 99,
+		Artist:    "Portishead",
+		Title:     "Dummy",
+		Year:      1994,
+		Tracks: []model.Track{
+			{Position: "1", Title: "Mysterons", Artist: "Portishead", Duration: 0},
+		},
+	}
+
+	var out bytes.Buffer
+	err := scrobbleRelease(
+		context.Background(),
+		config.Config{},
+		release,
+		time.Date(2026, 3, 20, 20, 0, 0, 0, time.UTC),
+		bufio.NewReader(strings.NewReader("300\n")),
+		&out,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("scrobbleRelease() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Dry run") {
+		t.Fatalf("scrobbleRelease() output missing dry-run note: %q", out.String())
+	}
+
+	paths, err := config.ResolvePaths()
+	if err != nil {
+		t.Fatalf("ResolvePaths() error = %v", err)
+	}
+	data, err := os.ReadFile(paths.DurationCache)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", paths.DurationCache, err)
+	}
+	if !strings.Contains(string(data), `"99|1|mysterons|portishead": 300`) {
+		t.Fatalf("duration cache missing prompted track duration: %s", string(data))
+	}
+}
+
+func chdirForAppTest(t *testing.T, dir string) func() {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(%q) error = %v", dir, err)
+	}
+
+	return func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore working directory to %q: %v", wd, err)
+		}
+	}
+}
+
+func writeUserConfig(t *testing.T, cfg string) {
+	t.Helper()
+
+	baseDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error = %v", err)
+	}
+	configDir := filepath.Join(baseDir, config.AppName)
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", configDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("WriteFile(config.json) error = %v", err)
+	}
+}

--- a/internal/app/helpers_test.go
+++ b/internal/app/helpers_test.go
@@ -237,8 +237,7 @@ func TestResolveDiscogsUsernameWrapsIdentityError(t *testing.T) {
 }
 
 func TestScrobbleReleaseDryRunSavesPromptedDurations(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	isolateAppConfigHome(t)
 	restore := chdirForAppTest(t, t.TempDir())
 	defer restore()
 
@@ -314,4 +313,12 @@ func writeUserConfig(t *testing.T, cfg string) {
 	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(cfg), 0o600); err != nil {
 		t.Fatalf("WriteFile(config.json) error = %v", err)
 	}
+}
+
+func isolateAppConfigHome(t *testing.T) {
+	t.Helper()
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempHome, ".config"))
 }

--- a/internal/app/prompts.go
+++ b/internal/app/prompts.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"cli-scrobbler/internal/discogs"
-	"cli-scrobbler/internal/lastfm"
 	"cli-scrobbler/internal/model"
 )
 
@@ -182,7 +181,7 @@ func promptLastFMSessionKey(reader *bufio.Reader, out io.Writer, apiKey, apiSecr
 }
 
 func guideLastFMSessionKey(reader *bufio.Reader, out io.Writer, apiKey, apiSecret string) (string, error) {
-	client := lastfm.NewClient(apiKey, apiSecret, "")
+	client := newLastFMClient(apiKey, apiSecret, "")
 	token, err := client.GetAuthToken(context.Background())
 	if err != nil {
 		return "", err

--- a/internal/app/workflow.go
+++ b/internal/app/workflow.go
@@ -11,7 +11,6 @@ import (
 	"cli-scrobbler/internal/cache"
 	"cli-scrobbler/internal/config"
 	"cli-scrobbler/internal/discogs"
-	"cli-scrobbler/internal/lastfm"
 	"cli-scrobbler/internal/model"
 	"cli-scrobbler/internal/scrobble"
 )
@@ -42,7 +41,7 @@ func scrobbleRelease(ctx context.Context, cfg config.Config, release model.Album
 		return err
 	}
 
-	client := lastfm.NewClient(cfg.LastFMAPIKey, cfg.LastFMAPISecret, cfg.LastFMSessionKey)
+	client := newLastFMClient(cfg.LastFMAPIKey, cfg.LastFMAPISecret, cfg.LastFMSessionKey)
 	if !noScrobble {
 		if err := client.Scrobble(ctx, timeline, release.Title); err != nil {
 			return err
@@ -57,7 +56,7 @@ func scrobbleRelease(ctx context.Context, cfg config.Config, release model.Album
 }
 
 func resolveRelease(ctx context.Context, cfg config.Config, query string, reader *bufio.Reader, out io.Writer) (model.Album, error) {
-	client := discogs.NewClient(cfg.DiscogsToken, cfg.DiscogsUserAgent)
+	client := newDiscogsClient(cfg.DiscogsToken, cfg.DiscogsUserAgent)
 	results, err := searchCollection(ctx, cfg, query)
 	if err != nil {
 		return model.Album{}, err
@@ -123,7 +122,7 @@ func hydrateDurations(release model.Album, store *cache.DurationStore, reader *b
 }
 
 func searchCollection(ctx context.Context, cfg config.Config, query string) ([]discogs.CollectionRelease, error) {
-	client := discogs.NewClient(cfg.DiscogsToken, cfg.DiscogsUserAgent)
+	client := newDiscogsClient(cfg.DiscogsToken, cfg.DiscogsUserAgent)
 	username, err := resolveDiscogsUsername(ctx, client, cfg)
 	if err != nil {
 		return nil, err

--- a/internal/discogs/client.go
+++ b/internal/discogs/client.go
@@ -86,8 +86,16 @@ type formatResponse struct {
 }
 
 func NewClient(token, userAgent string) *Client {
+	return NewClientWithHTTPClient(token, userAgent, &http.Client{Timeout: 15 * time.Second})
+}
+
+func NewClientWithHTTPClient(token, userAgent string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+
 	return &Client{
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		httpClient: httpClient,
 		token:      token,
 		userAgent:  userAgent,
 	}

--- a/internal/discogs/client_test.go
+++ b/internal/discogs/client_test.go
@@ -1,10 +1,22 @@
 package discogs
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestParseDuration(t *testing.T) {
 	t.Parallel()
@@ -95,5 +107,236 @@ func TestSearchCollection(t *testing.T) {
 
 	if got[0].ReleaseID != 1 {
 		t.Fatalf("top result release ID = %d, want 1", got[0].ReleaseID)
+	}
+}
+
+func TestIdentitySetsHeadersAndReturnsUsername(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("discogs-token", "agent/1.0")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/oauth/identity" {
+				t.Fatalf("request path = %q, want %q", req.URL.Path, "/oauth/identity")
+			}
+			if req.Header.Get("Authorization") != "Discogs token=discogs-token" {
+				t.Fatalf("Authorization header = %q", req.Header.Get("Authorization"))
+			}
+			if req.Header.Get("User-Agent") != "agent/1.0" {
+				t.Fatalf("User-Agent header = %q", req.Header.Get("User-Agent"))
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader(`{"username":"discogs-user"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	got, err := client.Identity(context.Background())
+	if err != nil {
+		t.Fatalf("Identity() error = %v", err)
+	}
+	if got != "discogs-user" {
+		t.Fatalf("Identity() = %q, want %q", got, "discogs-user")
+	}
+}
+
+func TestIdentityRequiresUsernameInResponse(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("discogs-token", "agent/1.0")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader(`{"username":"   "}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := client.Identity(context.Background())
+	if err == nil {
+		t.Fatal("Identity() error = nil, want error")
+	}
+	if err.Error() != "Discogs identity response did not include a username" {
+		t.Fatalf("Identity() error = %q, want username error", err.Error())
+	}
+}
+
+func TestCollectionReleasesPaginatesAndNormalizesValues(t *testing.T) {
+	t.Parallel()
+
+	pageRequests := 0
+	client := NewClient("discogs-token", "agent/1.0")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			pageRequests++
+			values, err := url.ParseQuery(req.URL.RawQuery)
+			if err != nil {
+				t.Fatalf("ParseQuery() error = %v", err)
+			}
+			switch values.Get("page") {
+			case "1":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body: io.NopCloser(strings.NewReader(`{
+						"pagination":{"page":1,"pages":2},
+						"releases":[
+							{"basic_information":{"id":1,"title":"Dummy","year":"1994","artists":[{"name":"Portishead (2)"}],"formats":[{"name":"LP"},{"name":"  "}]}}
+						]
+					}`)),
+					Header: make(http.Header),
+				}, nil
+			case "2":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body: io.NopCloser(strings.NewReader(`{
+						"pagination":{"page":2,"pages":2},
+						"releases":[
+							{"basic_information":{"id":2,"title":"Third","year":2008,"artists":[{"name":"Portishead"}],"formats":[{"name":"CD"}]}}
+						]
+					}`)),
+					Header: make(http.Header),
+				}, nil
+			default:
+				t.Fatalf("unexpected page %q", values.Get("page"))
+				return nil, nil
+			}
+		}),
+	}
+
+	got, err := client.CollectionReleases(context.Background(), "discogs-user")
+	if err != nil {
+		t.Fatalf("CollectionReleases() error = %v", err)
+	}
+	if pageRequests != 2 {
+		t.Fatalf("CollectionReleases() request count = %d, want %d", pageRequests, 2)
+	}
+	if len(got) != 2 {
+		t.Fatalf("CollectionReleases() len = %d, want %d", len(got), 2)
+	}
+	if got[0].Artist != "Portishead" {
+		t.Fatalf("CollectionReleases()[0].Artist = %q, want %q", got[0].Artist, "Portishead")
+	}
+	if len(got[0].Formats) != 1 || got[0].Formats[0] != "LP" {
+		t.Fatalf("CollectionReleases()[0].Formats = %#v, want %#v", got[0].Formats, []string{"LP"})
+	}
+}
+
+func TestGetReleaseSkipsHeadingsAndFallsBackToAlbumArtist(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("discogs-token", "agent/1.0")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/releases/7" {
+				t.Fatalf("request path = %q, want %q", req.URL.Path, "/releases/7")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body: io.NopCloser(strings.NewReader(`{
+					"id":7,
+					"title":"Dummy",
+					"year":"1994",
+					"artists":[{"name":"Portishead (2)"}],
+					"tracklist":[
+						{"position":"","title":"Side A","duration":"","type_":"heading"},
+						{"position":"A1","title":"Mysterons","duration":"5:02","type_":"track","artists":[]},
+						{"position":"A2","title":"Sour Times","duration":"4:11","type_":"track","artists":[{"name":"Beth Gibbons (2)"}]}
+					]
+				}`)),
+				Header: make(http.Header),
+			}, nil
+		}),
+	}
+
+	got, err := client.GetRelease(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("GetRelease() error = %v", err)
+	}
+	if got.Artist != "Portishead" {
+		t.Fatalf("GetRelease().Artist = %q, want %q", got.Artist, "Portishead")
+	}
+	if len(got.Tracks) != 2 {
+		t.Fatalf("GetRelease().Tracks len = %d, want %d", len(got.Tracks), 2)
+	}
+	if got.Tracks[0].Artist != "Portishead" {
+		t.Fatalf("GetRelease().Tracks[0].Artist = %q, want album artist fallback", got.Tracks[0].Artist)
+	}
+	if got.Tracks[1].Artist != "Beth Gibbons" {
+		t.Fatalf("GetRelease().Tracks[1].Artist = %q, want stripped artist suffix", got.Tracks[1].Artist)
+	}
+}
+
+func TestGetReleaseReturnsDurationParseError(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("discogs-token", "agent/1.0")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body: io.NopCloser(strings.NewReader(`{
+					"id":7,
+					"title":"Dummy",
+					"year":1994,
+					"artists":[{"name":"Portishead"}],
+					"tracklist":[
+						{"position":"A1","title":"Mysterons","duration":"bad","type_":"track"}
+					]
+				}`)),
+				Header: make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := client.GetRelease(context.Background(), 7)
+	if err == nil {
+		t.Fatal("GetRelease() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), `parse track duration for "Mysterons"`) {
+		t.Fatalf("GetRelease() error = %q, want wrapped duration error", err.Error())
+	}
+}
+
+func TestDoWrapsTransportAndDecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	transportErr := errors.New("boom")
+	client := NewClient("discogs-token", "agent/1.0")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, transportErr
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/oauth/identity", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	if err := client.do(req, &identityResponse{}); !errors.Is(err, transportErr) {
+		t.Fatalf("client.do() error = %v, want wrapped transport error", err)
+	}
+
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader("{")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	if err := client.do(req, &identityResponse{}); err == nil || !strings.Contains(err.Error(), "decode Discogs response") {
+		t.Fatalf("client.do() decode error = %v, want decode context", err)
 	}
 }

--- a/internal/lastfm/client.go
+++ b/internal/lastfm/client.go
@@ -47,8 +47,16 @@ type sessionPayload struct {
 }
 
 func NewClient(apiKey, apiSecret, sessionKey string) *Client {
+	return NewClientWithHTTPClient(apiKey, apiSecret, sessionKey, &http.Client{Timeout: 20 * time.Second})
+}
+
+func NewClientWithHTTPClient(apiKey, apiSecret, sessionKey string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 20 * time.Second}
+	}
+
 	return &Client{
-		httpClient: &http.Client{Timeout: 20 * time.Second},
+		httpClient: httpClient,
 		apiKey:     apiKey,
 		apiSecret:  apiSecret,
 		sessionKey: sessionKey,

--- a/internal/lastfm/client_test.go
+++ b/internal/lastfm/client_test.go
@@ -136,3 +136,129 @@ func TestScrobbleRequiresTracks(t *testing.T) {
 		t.Fatalf("Scrobble() error = %q, want %q", err.Error(), "no tracks to scrobble")
 	}
 }
+
+func TestGetAuthTokenSuccess(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("api-key", "api-secret", "")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Fatalf("request method = %q, want %q", req.Method, http.MethodPost)
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(request body) error = %v", err)
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				t.Fatalf("ParseQuery() error = %v", err)
+			}
+			if values.Get("method") != "auth.getToken" {
+				t.Fatalf("method = %q, want %q", values.Get("method"), "auth.getToken")
+			}
+			if values.Get("api_key") != "api-key" {
+				t.Fatalf("api_key = %q, want %q", values.Get("api_key"), "api-key")
+			}
+			if values.Get("api_sig") == "" {
+				t.Fatal("api_sig should not be empty")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"token":"token-123"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	got, err := client.GetAuthToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetAuthToken() error = %v", err)
+	}
+	if got != "token-123" {
+		t.Fatalf("GetAuthToken() = %q, want %q", got, "token-123")
+	}
+}
+
+func TestGetAuthTokenAPIError(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("api-key", "api-secret", "")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"error":4,"message":"Authentication failed"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := client.GetAuthToken(context.Background())
+	if err == nil {
+		t.Fatal("GetAuthToken() error = nil, want error")
+	}
+	if err.Error() != "Last.fm API error 4: Authentication failed" {
+		t.Fatalf("GetAuthToken() error = %q, want API error", err.Error())
+	}
+}
+
+func TestGetSessionKeySuccess(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("api-key", "api-secret", "")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(request body) error = %v", err)
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				t.Fatalf("ParseQuery() error = %v", err)
+			}
+			if values.Get("method") != "auth.getSession" {
+				t.Fatalf("method = %q, want %q", values.Get("method"), "auth.getSession")
+			}
+			if values.Get("token") != "token-123" {
+				t.Fatalf("token = %q, want %q", values.Get("token"), "token-123")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"session":{"key":"session-123"}}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	got, err := client.GetSessionKey(context.Background(), "token-123")
+	if err != nil {
+		t.Fatalf("GetSessionKey() error = %v", err)
+	}
+	if got != "session-123" {
+		t.Fatalf("GetSessionKey() = %q, want %q", got, "session-123")
+	}
+}
+
+func TestGetSessionKeyRequiresResponseKey(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("api-key", "api-secret", "")
+	client.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"session":{"key":"   "}}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := client.GetSessionKey(context.Background(), "token-123")
+	if err == nil {
+		t.Fatal("GetSessionKey() error = nil, want error")
+	}
+	if err.Error() != "Last.fm session response did not include a session key" {
+		t.Fatalf("GetSessionKey() error = %q, want missing key error", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- add targeted coverage for app prompts, wizard/workflow helpers, auth flows, and search/scrobble command paths
- add HTTP-driven tests for Discogs client methods and Last.fm auth methods
- add small constructor seams for injecting custom HTTP clients in tests without changing runtime behavior

## Validation
- go test ./...
- go build -o scrobble ./cmd/scrobble

## Coverage
- total coverage increased from about 37.4% to 72.4%
- internal/app: 64.3%
- internal/discogs: 84.5%
- internal/lastfm: 86.4%